### PR TITLE
Feature/update pendulum 2.1

### DIFF
--- a/mag_archiver/mag.py
+++ b/mag_archiver/mag.py
@@ -29,39 +29,39 @@ from mag_archiver.azure import copy_container, delete_container, list_containers
 
 
 class MagState(Enum):
-    """ The state of the MAG release """
+    """The state of the MAG release"""
 
-    discovered = 'discovered'
-    archived = 'archived'
-    done = 'done'
+    discovered = "discovered"
+    archived = "archived"
+    done = "done"
 
 
 class MagTask(Enum):
-    """ The current task being executed """
+    """The current task being executed"""
 
-    not_started = 'not-started'
-    copying_to_vm = 'copying-to-vm'
-    archiving = 'archiving'
-    copying_to_release_container = 'copying-to-release-container'
-    cleaning_up = 'cleaning-up'
-    done = 'done'
+    not_started = "not-started"
+    copying_to_vm = "copying-to-vm"
+    archiving = "archiving"
+    copying_to_release_container = "copying-to-release-container"
+    cleaning_up = "cleaning-up"
+    done = "done"
 
 
 class MagDateType(Enum):
-    """ The date field type """
+    """The date field type"""
 
-    release = 'ReleaseDate'
-    discovered = 'DiscoveredDate'
-    archived = 'ArchivedDate'
-    done = 'DoneDate'
+    release = "ReleaseDate"
+    discovered = "DiscoveredDate"
+    archived = "ArchivedDate"
+    done = "DoneDate"
 
     @classmethod
     def map(cls):
         return {
-            MagDateType.release: 'release_date',
-            MagDateType.discovered: 'discovered_date',
-            MagDateType.archived: 'archived_date',
-            MagDateType.done: 'done_date',
+            MagDateType.release: "release_date",
+            MagDateType.discovered: "discovered_date",
+            MagDateType.archived: "archived_date",
+            MagDateType.done: "done_date",
         }
 
     def attr(self):
@@ -69,9 +69,13 @@ class MagDateType(Enum):
         return map_[self]
 
 
-def make_mag_query(start_date: Optional[pendulum.Date] = None, end_date: Optional[pendulum.Date] = None,
-                   state: Optional[MagState] = None, date_type: MagDateType = MagDateType.release) -> str:
-    """ Build a query for the MagReleases table.
+def make_mag_query(
+    start_date: Optional[pendulum.Date] = None,
+    end_date: Optional[pendulum.Date] = None,
+    state: Optional[MagState] = None,
+    date_type: MagDateType = MagDateType.release,
+) -> str:
+    """Build a query for the MagReleases table.
 
     :param start_date: start date for the query (inclusive).
     :param end_date: end date for the query (exclusive).
@@ -81,7 +85,7 @@ def make_mag_query(start_date: Optional[pendulum.Date] = None, end_date: Optiona
     """
 
     commands = []
-    date_format = '%Y-%m-%dT%H:%MZ'
+    date_format = "%Y-%m-%dT%H:%MZ"
 
     if state is not None:
         commands.append(f"State eq '{state.value}'")
@@ -92,12 +96,12 @@ def make_mag_query(start_date: Optional[pendulum.Date] = None, end_date: Optiona
     if end_date is not None:
         commands.append(f"{date_type.value} lt datetime'{end_date.strftime(date_format)}'")
 
-    query = ' and '.join(commands)
+    query = " and ".join(commands)
     return query
 
 
 def hide_if_not_none(secret: Any):
-    """ Hide a secret unless it is None, which means that the user didn't set it.
+    """Hide a secret unless it is None, which means that the user didn't set it.
 
     :param secret: the secret.
     :return: None or 'hidden'
@@ -105,14 +109,13 @@ def hide_if_not_none(secret: Any):
 
     value = None
     if secret is not None:
-        value = 'hidden'
+        value = "hidden"
     return value
 
 
 class MagContainer:
-
-    def __init__(self, name: str, last_modified: pendulum.Date, release_date: pendulum.Date):
-        """ Microsoft Academic Graph container class.
+    def __init__(self, name: str, last_modified: pendulum.DateTime, release_date: pendulum.Date):
+        """Microsoft Academic Graph container class.
 
         :param name: name of the container.
         :param last_modified: date that the container was last modified.
@@ -124,33 +127,48 @@ class MagContainer:
         self.release_date = release_date
 
     def __str__(self):
-        return f'Mag Container {self.name}'
+        return f"Mag Container {self.name}"
 
     def __repr__(self):
-        return f'MagContainer({self.name}, {self.last_modified.strftime("%Y-%m-%d")}, ' \
-               f'{self.release_date.strftime("%Y-%m-%d")})'
+        return (
+            f'MagContainer({self.name}, {self.last_modified.strftime("%Y-%m-%d")}, '
+            f'{self.release_date.strftime("%Y-%m-%d")})'
+        )
 
 
 class MagRelease:
-    TABLE_NAME = 'MagReleases'
-    __PARTITION_KEY = 'PartitionKey'
-    __ROW_KEY = 'RowKey'
-    __STATE = 'State'
-    __TASK = 'Task'
-    __RELEASE_DATE = 'ReleaseDate'
-    __SOURCE_CONTAINER = 'SourceContainer'
-    __SOURCE_CONTAINER_LAST_MODIFIED = 'SourceContainerLastModified'
-    __RELEASE_CONTAINER = 'ReleaseContainer'
-    __RELEASE_PATH = 'ReleasePath'
-    __DISCOVERED_DATE = 'DiscoveredDate'
-    __ARCHIVED_DATE = 'ArchivedDate'
-    __DONE_DATE = 'DoneDate'
+    TABLE_NAME = "MagReleases"
+    __PARTITION_KEY = "PartitionKey"
+    __ROW_KEY = "RowKey"
+    __STATE = "State"
+    __TASK = "Task"
+    __RELEASE_DATE = "ReleaseDate"
+    __SOURCE_CONTAINER = "SourceContainer"
+    __SOURCE_CONTAINER_LAST_MODIFIED = "SourceContainerLastModified"
+    __RELEASE_CONTAINER = "ReleaseContainer"
+    __RELEASE_PATH = "ReleasePath"
+    __DISCOVERED_DATE = "DiscoveredDate"
+    __ARCHIVED_DATE = "ArchivedDate"
+    __DONE_DATE = "DoneDate"
 
-    def __init__(self, partition_key: str, row_key: str, state: MagState, task: MagTask, release_date: pendulum.date,
-                 source_container: str, source_container_last_modified: pendulum.date, release_container: str,
-                 release_path: str, discovered_date: pendulum.date, archived_date: pendulum.date, done_date: pendulum.date,
-                 account_name: Optional[str] = None, account_key: Optional[str] = None):
-        """ Microsoft Academic Graph release class.
+    def __init__(
+        self,
+        partition_key: str,
+        row_key: str,
+        state: MagState,
+        task: MagTask,
+        release_date: pendulum.Date,
+        source_container: str,
+        source_container_last_modified: pendulum.DateTime,
+        release_container: str,
+        release_path: str,
+        discovered_date: pendulum.DateTime,
+        archived_date: pendulum.DateTime,
+        done_date: pendulum.DateTime,
+        account_name: Optional[str] = None,
+        account_key: Optional[str] = None,
+    ):
+        """Microsoft Academic Graph release class.
 
         :param partition_key: partition key.
         :param row_key: the row key. partition_key + row_key form the primary key.
@@ -193,7 +211,7 @@ class MagRelease:
         return TableService(account_name=self.account_name, account_key=self.account_key)
 
     def create(self) -> bool:
-        """ Create the MagRelease instance in the MagReleases table.
+        """Create the MagRelease instance in the MagReleases table.
 
         :return: whether the instance was created or not.
         """
@@ -210,7 +228,7 @@ class MagRelease:
         return success
 
     def delete(self) -> None:
-        """ Delete this MagRelease instance from the MagReleases table.
+        """Delete this MagRelease instance from the MagReleases table.
 
         :return: None.
         """
@@ -220,7 +238,7 @@ class MagRelease:
         service.delete_entity(MagRelease.TABLE_NAME, self.partition_key, self.row_key)
 
     def archive(self, target_container: str, target_folder: str):
-        """ Archive this MAG release into to the target container.
+        """Archive this MAG release into to the target container.
 
         TODO: in the future this method should compress the release before copying it.
 
@@ -230,11 +248,12 @@ class MagRelease:
         """
 
         self.__assert_account("MagRelease.archive: account_name and account_key must be supplied.")
-        return copy_container(self.account_name, self.account_key, self.source_container, target_container,
-                              target_folder)
+        return copy_container(
+            self.account_name, self.account_key, self.source_container, target_container, target_folder
+        )
 
     def cleanup(self):
-        """ Cleanup the source container.
+        """Cleanup the source container.
 
         :return:
         """
@@ -243,7 +262,7 @@ class MagRelease:
         return delete_container(self.account_name, self.account_key, self.source_container)
 
     def update(self):
-        """ Update this MAG release instance in the MagReleases table.
+        """Update this MAG release instance in the MagReleases table.
 
         :return:
         """
@@ -256,7 +275,7 @@ class MagRelease:
 
     @staticmethod
     def from_entity(entity: dict, account_name: Optional[str] = None, account_key: Optional[str] = None):
-        """ Create a MagRelease instance from an entity dictionary.
+        """Create a MagRelease instance from an entity dictionary.
 
         :param entity: the entity returned from the Azure Table Storage API.
         :param account_name: Azure Storage account name. Optional, only required if the create, delete, archive,
@@ -279,12 +298,25 @@ class MagRelease:
         archived_date_ = pendulum.instance(entity[MagRelease.__ARCHIVED_DATE])
         done_date_ = pendulum.instance(entity[MagRelease.__DONE_DATE])
 
-        return MagRelease(partition_key_, row_key_, state_, task_, release_date_, source_container_,
-                          source_container_last_modified_, release_container_, release_path_, discovered_date_,
-                          archived_date_, done_date_, account_name=account_name, account_key=account_key)
+        return MagRelease(
+            partition_key_,
+            row_key_,
+            state_,
+            task_,
+            release_date_,
+            source_container_,
+            source_container_last_modified_,
+            release_container_,
+            release_path_,
+            discovered_date_,
+            archived_date_,
+            done_date_,
+            account_name=account_name,
+            account_key=account_key,
+        )
 
     def to_entity(self) -> dict:
-        """ Convert a MagRelease instance into an Azure Table Storage entity.
+        """Convert a MagRelease instance into an Azure Table Storage entity.
 
         :return: an Azure Table Storage entity.
         """
@@ -296,8 +328,9 @@ class MagRelease:
         entity[MagRelease.__TASK] = self.task.value
         entity[MagRelease.__RELEASE_DATE] = EntityProperty(EdmType.DATETIME, value=self.release_date)
         entity[MagRelease.__SOURCE_CONTAINER] = self.source_container
-        entity[MagRelease.__SOURCE_CONTAINER_LAST_MODIFIED] = \
-            EntityProperty(EdmType.DATETIME, value=self.source_container_last_modified)
+        entity[MagRelease.__SOURCE_CONTAINER_LAST_MODIFIED] = EntityProperty(
+            EdmType.DATETIME, value=self.source_container_last_modified
+        )
         entity[MagRelease.__RELEASE_CONTAINER] = self.release_container
         entity[MagRelease.__RELEASE_PATH] = self.release_path
         entity[MagRelease.__DISCOVERED_DATE] = EntityProperty(EdmType.DATETIME, value=self.discovered_date)
@@ -309,30 +342,33 @@ class MagRelease:
         return f'MagRelease {self.release_date.strftime("%Y-%m-%d")}'
 
     def __repr__(self):
-        dt_format = '%Y-%m-%dT%H:%MZ'
+        dt_format = "%Y-%m-%dT%H:%MZ"
 
-        return 'MagRelease(' \
-               f'{self.partition_key}, ' \
-               f'{self.row_key}, ' \
-               f'{self.state.value}, ' \
-               f'{self.task.value}, ' \
-               f'{self.release_date.strftime(dt_format)}, ' \
-               f'{self.source_container}, ' \
-               f'{self.source_container_last_modified.strftime(dt_format)}, ' \
-               f'{self.release_container}, ' \
-               f'{self.release_path}, ' \
-               f'{self.discovered_date.strftime(dt_format)}, ' \
-               f'{self.archived_date.strftime(dt_format)}, ' \
-               f'{self.done_date.strftime(dt_format)}, ' \
-               f'account_name={self.account_name}, ' \
-               f'account_key={hide_if_not_none(self.account_key)})'
+        return (
+            "MagRelease("
+            f"{self.partition_key}, "
+            f"{self.row_key}, "
+            f"{self.state.value}, "
+            f"{self.task.value}, "
+            f"{self.release_date.strftime(dt_format)}, "
+            f"{self.source_container}, "
+            f"{self.source_container_last_modified.strftime(dt_format)}, "
+            f"{self.release_container}, "
+            f"{self.release_path}, "
+            f"{self.discovered_date.strftime(dt_format)}, "
+            f"{self.archived_date.strftime(dt_format)}, "
+            f"{self.done_date.strftime(dt_format)}, "
+            f"account_name={self.account_name}, "
+            f"account_key={hide_if_not_none(self.account_key)})"
+        )
 
 
 class MagArchiverClient:
     __MAG_RELEASE_RE = re.compile("mag-[0-9]{4}-[0-9]{2}-[0-9]{2}")
 
-    def __init__(self, account_name: Optional[str] = None, account_key: Optional[str] = None,
-                 sas_token: Optional[str] = None):
+    def __init__(
+        self, account_name: Optional[str] = None, account_key: Optional[str] = None, sas_token: Optional[str] = None
+    ):
         """
 
         :param account_name: the name of the Azure Storage account where the Microsoft Academic Graph releases are
@@ -345,9 +381,10 @@ class MagArchiverClient:
         self.account_key = account_key
         self.sas_token = sas_token
 
-    def list_containers(self, last_modified_thresh: Optional[float] = None, reverse: bool = False) \
-            -> List[MagContainer]:
-        """ List all Azure Storage Blob Containers holding MAG releases.
+    def list_containers(
+        self, last_modified_thresh: Optional[float] = None, reverse: bool = False
+    ) -> List[MagContainer]:
+        """List all Azure Storage Blob Containers holding MAG releases.
 
         :param last_modified_thresh: only include containers that were last modified greater than or equal to a
         specific number of hours.
@@ -358,7 +395,7 @@ class MagArchiverClient:
         # List all containers in the storage account
         containers: List[ContainerProperties] = list_containers(self.account_name, self.account_key)
 
-        tz = pendulum.timezone('UTC')
+        tz = pendulum.timezone("UTC")
         current_time = pendulum.now(tz)
 
         # Select all containers containing MAG releases that were last updated greater than
@@ -383,7 +420,7 @@ class MagArchiverClient:
         return mag_containers
 
     def update_releases(self, containers: List[MagContainer]):
-        """ Update the releases in the MagReleases table based on a list of containers containing MAG releases.
+        """Update the releases in the MagReleases table based on a list of containers containing MAG releases.
 
         :param containers: the containers containing MAG releases.
         :return: the number of releases created and the number of errors.
@@ -397,8 +434,10 @@ class MagArchiverClient:
         entities = table_service.query_entities(MagRelease.TABLE_NAME)
 
         # Get all containers that are not in the MagReleases table
-        new_container_index = dict.fromkeys(set([container.name for container in containers]) -
-                                            set([entity['SourceContainer'] for entity in entities]), 0)
+        new_container_index = dict.fromkeys(
+            set([container.name for container in containers]) - set([entity["SourceContainer"] for entity in entities]),
+            0,
+        )
         num_new_containers = len(new_container_index)
         logging.info(f"Num new containers discovered: {num_new_containers}")
 
@@ -407,12 +446,24 @@ class MagArchiverClient:
         num_errors = 0
         for container in containers:
             if container.name in new_container_index:
-                partition_key = 'mag'
+                partition_key = "mag"
                 row_key = container.release_date.strftime("%Y-%m-%d")
-                release = MagRelease(partition_key, row_key, MagState.discovered, MagTask.not_started,
-                                     container.release_date, container.name, container.last_modified, '', '',
-                                     discovered_date, min_date, min_date, account_name=self.account_name,
-                                     account_key=self.account_key)
+                release = MagRelease(
+                    partition_key,
+                    row_key,
+                    MagState.discovered,
+                    MagTask.not_started,
+                    container.release_date,
+                    container.name,
+                    container.last_modified,
+                    "",
+                    "",
+                    discovered_date,
+                    min_date,
+                    min_date,
+                    account_name=self.account_name,
+                    account_key=self.account_key,
+                )
                 success = release.create()
                 if success:
                     num_created += 1
@@ -420,10 +471,15 @@ class MagArchiverClient:
                     num_errors += 1
         return num_created, num_errors
 
-    def list_releases(self, start_date: Optional[pendulum.Date] = None,
-                      end_date: Optional[pendulum.Date] = None, state: Optional[MagState] = None,
-                      date_type: MagDateType = MagDateType.release, reverse: bool = False) -> List[MagRelease]:
-        """ List Microsoft Academic releases in the MagReleases Azure Storage Table.
+    def list_releases(
+        self,
+        start_date: Optional[pendulum.DateTime] = None,
+        end_date: Optional[pendulum.DateTime] = None,
+        state: Optional[MagState] = None,
+        date_type: MagDateType = MagDateType.release,
+        reverse: bool = False,
+    ) -> List[MagRelease]:
+        """List Microsoft Academic releases in the MagReleases Azure Storage Table.
 
         :param start_date: start date for the query.
         :param end_date: end date for the query.
@@ -434,10 +490,11 @@ class MagArchiverClient:
         """
 
         # Query and fetch releases
-        table_service = TableService(account_name=self.account_name, account_key=self.account_key,
-                                     sas_token=self.sas_token)
+        table_service = TableService(
+            account_name=self.account_name, account_key=self.account_key, sas_token=self.sas_token
+        )
         query = make_mag_query(start_date=start_date, end_date=end_date, state=state, date_type=date_type)
-        entities = table_service.query_entities('MagReleases', filter=query)
+        entities = table_service.query_entities("MagReleases", filter=query)
 
         # Convert entities into MagRelease objects
         releases = []
@@ -453,7 +510,9 @@ class MagArchiverClient:
         return self.__repr__()
 
     def __repr__(self):
-        return 'MagArchiverClient(' \
-               f'account_name={self.account_name}, ' \
-               f'account_key={hide_if_not_none(self.account_key)}, ' \
-               f'sas_token={hide_if_not_none(self.sas_token)})'
+        return (
+            "MagArchiverClient("
+            f"account_name={self.account_name}, "
+            f"account_key={hide_if_not_none(self.account_key)}, "
+            f"sas_token={hide_if_not_none(self.sas_token)})"
+        )

--- a/mag_archiver/mag.py
+++ b/mag_archiver/mag.py
@@ -69,7 +69,7 @@ class MagDateType(Enum):
         return map_[self]
 
 
-def make_mag_query(start_date: Optional[pendulum.date] = None, end_date: Optional[pendulum.date] = None,
+def make_mag_query(start_date: Optional[pendulum.Date] = None, end_date: Optional[pendulum.Date] = None,
                    state: Optional[MagState] = None, date_type: MagDateType = MagDateType.release) -> str:
     """ Build a query for the MagReleases table.
 
@@ -111,7 +111,7 @@ def hide_if_not_none(secret: Any):
 
 class MagContainer:
 
-    def __init__(self, name: str, last_modified: pendulum.date, release_date: pendulum.date):
+    def __init__(self, name: str, last_modified: pendulum.Date, release_date: pendulum.Date):
         """ Microsoft Academic Graph container class.
 
         :param name: name of the container.
@@ -420,8 +420,8 @@ class MagArchiverClient:
                     num_errors += 1
         return num_created, num_errors
 
-    def list_releases(self, start_date: Optional[pendulum.date] = None,
-                      end_date: Optional[pendulum.date] = None, state: Optional[MagState] = None,
+    def list_releases(self, start_date: Optional[pendulum.Date] = None,
+                      end_date: Optional[pendulum.Date] = None, state: Optional[MagState] = None,
                       date_type: MagDateType = MagDateType.release, reverse: bool = False) -> List[MagRelease]:
         """ List Microsoft Academic releases in the MagReleases Azure Storage Table.
 

--- a/mag_archiver/mag.py
+++ b/mag_archiver/mag.py
@@ -70,8 +70,8 @@ class MagDateType(Enum):
 
 
 def make_mag_query(
-    start_date: Optional[pendulum.Date] = None,
-    end_date: Optional[pendulum.Date] = None,
+    start_date: Optional[pendulum.DateTime] = None,
+    end_date: Optional[pendulum.DateTime] = None,
     state: Optional[MagState] = None,
     date_type: MagDateType = MagDateType.release,
 ) -> str:

--- a/mag_archiver/mag.py
+++ b/mag_archiver/mag.py
@@ -359,7 +359,7 @@ class MagArchiverClient:
         containers: List[ContainerProperties] = list_containers(self.account_name, self.account_key)
 
         tz = pendulum.timezone('UTC')
-        current_time = pendulum.datetime.now(tz)
+        current_time = pendulum.now(tz)
 
         # Select all containers containing MAG releases that were last updated greater than
         mag_containers = []

--- a/mag_archiver/mag.py
+++ b/mag_archiver/mag.py
@@ -17,17 +17,15 @@
 import logging
 import re
 from enum import Enum
-from typing import Optional, List, Any
+from typing import Any, List, Optional
 
 import pendulum
+
 from azure.common import AzureConflictHttpError
-from azure.cosmosdb.table.models import EntityProperty, EdmType
+from azure.cosmosdb.table.models import EdmType, EntityProperty
 from azure.cosmosdb.table.tableservice import TableService
 from azure.storage.blob import ContainerProperties
-from pendulum import Pendulum
-
-from mag_archiver.azure import copy_container, delete_container
-from mag_archiver.azure import list_containers
+from mag_archiver.azure import copy_container, delete_container, list_containers
 
 
 class MagState(Enum):
@@ -71,7 +69,7 @@ class MagDateType(Enum):
         return map_[self]
 
 
-def make_mag_query(start_date: Optional[Pendulum] = None, end_date: Optional[Pendulum] = None,
+def make_mag_query(start_date: Optional[pendulum.date] = None, end_date: Optional[pendulum.date] = None,
                    state: Optional[MagState] = None, date_type: MagDateType = MagDateType.release) -> str:
     """ Build a query for the MagReleases table.
 
@@ -113,7 +111,7 @@ def hide_if_not_none(secret: Any):
 
 class MagContainer:
 
-    def __init__(self, name: str, last_modified: Pendulum, release_date: Pendulum):
+    def __init__(self, name: str, last_modified: pendulum.date, release_date: pendulum.date):
         """ Microsoft Academic Graph container class.
 
         :param name: name of the container.
@@ -148,9 +146,9 @@ class MagRelease:
     __ARCHIVED_DATE = 'ArchivedDate'
     __DONE_DATE = 'DoneDate'
 
-    def __init__(self, partition_key: str, row_key: str, state: MagState, task: MagTask, release_date: Pendulum,
-                 source_container: str, source_container_last_modified: Pendulum, release_container: str,
-                 release_path: str, discovered_date: Pendulum, archived_date: Pendulum, done_date: Pendulum,
+    def __init__(self, partition_key: str, row_key: str, state: MagState, task: MagTask, release_date: pendulum.date,
+                 source_container: str, source_container_last_modified: pendulum.date, release_container: str,
+                 release_path: str, discovered_date: pendulum.date, archived_date: pendulum.date, done_date: pendulum.date,
                  account_name: Optional[str] = None, account_key: Optional[str] = None):
         """ Microsoft Academic Graph release class.
 
@@ -422,8 +420,8 @@ class MagArchiverClient:
                     num_errors += 1
         return num_created, num_errors
 
-    def list_releases(self, start_date: Optional[Pendulum] = None,
-                      end_date: Optional[Pendulum] = None, state: Optional[MagState] = None,
+    def list_releases(self, start_date: Optional[pendulum.date] = None,
+                      end_date: Optional[pendulum.date] = None, state: Optional[MagState] = None,
                       date_type: MagDateType = MagDateType.release, reverse: bool = False) -> List[MagRelease]:
         """ List Microsoft Academic releases in the MagReleases Azure Storage Table.
 

--- a/mag_archiver/mag_archiver.py
+++ b/mag_archiver/mag_archiver.py
@@ -84,7 +84,7 @@ def main(timer: func.TimerRequest) -> None:
         release.state = MagState.archived
         release.release_container = target_container
         release.release_path = target_folder
-        release.archived_date = pendulum.utcnow()
+        release.archived_date = pendulum.now('UTC')
         release.task = MagTask.cleaning_up
         logging.info(f'Update state to archived: {release}')
         release.update()
@@ -100,7 +100,7 @@ def main(timer: func.TimerRequest) -> None:
         # - set done date to now
         release.state = MagState.done
         release.task = MagTask.done
-        release.done_date = pendulum.utcnow()
+        release.done_date = pendulum.now('UTC')
         logging.info(f'Update state to done: {release}')
         release.update()
         logging.info(f'Update state to done finished: {release}')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 azure-cosmosdb-table==1.0.*
 azure-functions==1.2.*
 azure-storage-blob==12.3.*
-pendulum==1.4.*
+pendulum==2.1.*

--- a/tests/test_mag.py
+++ b/tests/test_mag.py
@@ -339,7 +339,7 @@ class TestMagArchiverClient(unittest.TestCase):
                 service.delete_entity(MagRelease.TABLE_NAME, "mag", container.name.replace("mag-", ""))
 
     @patch("mag_archiver.mag.list_containers")
-    @patch("pendulum.datetime.now")
+    @patch("pendulum.now")
     def test_list_releases(self, mock_now, mock_list_containers):
         # Mock time
         mock_now.return_value = pendulum.datetime(year=2020, month=5, day=1, hour=1)

--- a/tests/test_mag.py
+++ b/tests/test_mag.py
@@ -23,26 +23,31 @@ import pendulum
 from azure.common import AzureMissingResourceHttpError
 from azure.cosmosdb.table.tableservice import TableService
 from azure.storage.blob import ContainerProperties
-
 from mag_archiver.azure import create_table
-from mag_archiver.mag import make_mag_query, MagState, MagDateType, MagRelease, MagTask, MagArchiverClient, \
-    hide_if_not_none
+from mag_archiver.mag import (
+    MagArchiverClient,
+    MagDateType,
+    MagRelease,
+    MagState,
+    MagTask,
+    hide_if_not_none,
+    make_mag_query,
+)
 
 
 class TestMag(unittest.TestCase):
-
     def test_hide_if_not_none(self):
         # Test that None is returned for None
         value = hide_if_not_none(None)
         self.assertEqual(value, None)
 
         # Test that 'hidden' is returned: string
-        value = hide_if_not_none('hello world')
-        self.assertEqual(value, 'hidden')
+        value = hide_if_not_none("hello world")
+        self.assertEqual(value, "hidden")
 
         # Test that 'hidden' is returned: integer
         value = hide_if_not_none(123)
-        self.assertEqual(value, 'hidden')
+        self.assertEqual(value, "hidden")
 
     def test_make_mag_query(self):
         start_date = pendulum.datetime(year=2020, month=4, day=1)
@@ -50,7 +55,7 @@ class TestMag(unittest.TestCase):
 
         # No parameters
         query = make_mag_query()
-        self.assertEqual(query, '')
+        self.assertEqual(query, "")
 
         # State parameter
         query = make_mag_query(state=MagState.discovered)
@@ -90,78 +95,107 @@ class TestMag(unittest.TestCase):
 
         # Start date, end date and date type
         query = make_mag_query(start_date=start_date, end_date=end_date, date_type=MagDateType.release)
-        self.assertEqual(query, "ReleaseDate ge datetime'2020-04-01T00:00Z' and ReleaseDate lt "
-                                "datetime'2020-05-01T00:00Z'")
+        self.assertEqual(
+            query, "ReleaseDate ge datetime'2020-04-01T00:00Z' and ReleaseDate lt " "datetime'2020-05-01T00:00Z'"
+        )
 
         query = make_mag_query(start_date=start_date, end_date=end_date, date_type=MagDateType.discovered)
-        self.assertEqual(query, "DiscoveredDate ge datetime'2020-04-01T00:00Z' and DiscoveredDate lt "
-                                "datetime'2020-05-01T00:00Z'")
+        self.assertEqual(
+            query, "DiscoveredDate ge datetime'2020-04-01T00:00Z' and DiscoveredDate lt " "datetime'2020-05-01T00:00Z'"
+        )
 
         query = make_mag_query(start_date=start_date, end_date=end_date, date_type=MagDateType.archived)
-        self.assertEqual(query, "ArchivedDate ge datetime'2020-04-01T00:00Z' and ArchivedDate lt "
-                                "datetime'2020-05-01T00:00Z'")
+        self.assertEqual(
+            query, "ArchivedDate ge datetime'2020-04-01T00:00Z' and ArchivedDate lt " "datetime'2020-05-01T00:00Z'"
+        )
 
         query = make_mag_query(start_date=start_date, end_date=end_date, date_type=MagDateType.done)
-        self.assertEqual(query, "DoneDate ge datetime'2020-04-01T00:00Z' and DoneDate lt "
-                                "datetime'2020-05-01T00:00Z'")
+        self.assertEqual(
+            query, "DoneDate ge datetime'2020-04-01T00:00Z' and DoneDate lt " "datetime'2020-05-01T00:00Z'"
+        )
 
         # State, start date, end date and date type
-        query = make_mag_query(state=MagState.discovered, start_date=start_date, end_date=end_date,
-                               date_type=MagDateType.discovered)
-        self.assertEqual(query, "State eq 'discovered' and DiscoveredDate ge datetime'2020-04-01T00:00Z' "
-                                "and DiscoveredDate lt datetime'2020-05-01T00:00Z'")
+        query = make_mag_query(
+            state=MagState.discovered, start_date=start_date, end_date=end_date, date_type=MagDateType.discovered
+        )
+        self.assertEqual(
+            query,
+            "State eq 'discovered' and DiscoveredDate ge datetime'2020-04-01T00:00Z' "
+            "and DiscoveredDate lt datetime'2020-05-01T00:00Z'",
+        )
 
-        query = make_mag_query(state=MagState.archived, start_date=start_date, end_date=end_date,
-                               date_type=MagDateType.archived)
-        self.assertEqual(query, "State eq 'archived' and ArchivedDate ge datetime'2020-04-01T00:00Z' "
-                                "and ArchivedDate lt datetime'2020-05-01T00:00Z'")
+        query = make_mag_query(
+            state=MagState.archived, start_date=start_date, end_date=end_date, date_type=MagDateType.archived
+        )
+        self.assertEqual(
+            query,
+            "State eq 'archived' and ArchivedDate ge datetime'2020-04-01T00:00Z' "
+            "and ArchivedDate lt datetime'2020-05-01T00:00Z'",
+        )
 
-        query = make_mag_query(state=MagState.done, start_date=start_date, end_date=end_date,
-                               date_type=MagDateType.done)
-        self.assertEqual(query, "State eq 'done' and DoneDate ge datetime'2020-04-01T00:00Z' "
-                                "and DoneDate lt datetime'2020-05-01T00:00Z'")
+        query = make_mag_query(
+            state=MagState.done, start_date=start_date, end_date=end_date, date_type=MagDateType.done
+        )
+        self.assertEqual(
+            query,
+            "State eq 'done' and DoneDate ge datetime'2020-04-01T00:00Z' "
+            "and DoneDate lt datetime'2020-05-01T00:00Z'",
+        )
 
 
 def make_mag_release(account_name: str, account_key: str, year: int, month: int, day: int):
     min_date = pendulum.datetime(1601, 1, 1)
-    partition_key_ = 'mag'
-    row_key_ = f'mag-{year:0>4d}-{month:0>2d}-{day:0>2d}'
+    partition_key_ = "mag"
+    row_key_ = f"mag-{year:0>4d}-{month:0>2d}-{day:0>2d}"
     state_ = MagState.discovered
     task_ = MagTask.not_started
     release_date_ = pendulum.datetime(year=year, month=month, day=day)
     source_container_ = row_key_
     source_container_last_modified_ = pendulum.datetime(year=year, month=month, day=day, hour=1)
-    release_container_ = ''
-    release_path_ = ''
+    release_container_ = ""
+    release_path_ = ""
     discovered_date_ = pendulum.datetime(year=year, month=month, day=day, hour=2)
     archived_date_ = min_date
     done_date_ = min_date
-    return MagRelease(partition_key_, row_key_, state_, task_, release_date_, source_container_,
-                      source_container_last_modified_, release_container_, release_path_, discovered_date_,
-                      archived_date_, done_date_, account_name=account_name, account_key=account_key)
+    return MagRelease(
+        partition_key_,
+        row_key_,
+        state_,
+        task_,
+        release_date_,
+        source_container_,
+        source_container_last_modified_,
+        release_container_,
+        release_path_,
+        discovered_date_,
+        archived_date_,
+        done_date_,
+        account_name=account_name,
+        account_key=account_key,
+    )
 
 
 class TestMagRelease(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(TestMagRelease, self).__init__(*args, **kwargs)
-        self.account_name = os.getenv('TEST_AZURE_STORAGE_ACCOUNT_NAME')
-        self.account_key = os.getenv('TEST_AZURE_STORAGE_ACCOUNT_KEY')
+        self.account_name = os.getenv("TEST_AZURE_STORAGE_ACCOUNT_NAME")
+        self.account_key = os.getenv("TEST_AZURE_STORAGE_ACCOUNT_KEY")
         create_table(self.account_name, self.account_key, MagRelease.TABLE_NAME)
 
     def test_secrets_hidden(self):
         # Check that account key is hidden
-        account_name = 'myaccountname'
-        secret = 'secret'
+        account_name = "myaccountname"
+        secret = "secret"
 
         # Check that account_key and sas_token are hidden
         release = make_mag_release(account_name, secret, 2020, 1, 1)
-        self.assertIn('account_key=hidden', release.__repr__())
+        self.assertIn("account_key=hidden", release.__repr__())
         self.assertNotIn(secret, release.__str__())
         self.assertNotIn(secret, release.__repr__())
 
         # Check that account_key is None
         release = make_mag_release(account_name, None, 2020, 1, 1)
-        self.assertIn('account_key=None', release.__repr__())
+        self.assertIn("account_key=None", release.__repr__())
 
     def test_create(self):
         release = make_mag_release(self.account_name, self.account_key, 2019, 6, 1)
@@ -189,7 +223,7 @@ class TestMagRelease(unittest.TestCase):
 
             # Update release
             release.state = MagState.archived
-            release.archived_date = pendulum.now('UTC').microsecond
+            release.archived_date = pendulum.now("UTC").microsecond
             release.update()
 
             # Verify that release is updated
@@ -205,17 +239,17 @@ class TestMagRelease(unittest.TestCase):
 def make_containers():
     containers = []
     cp1 = ContainerProperties()
-    cp1.name = 'mag-2020-04-17'
+    cp1.name = "mag-2020-04-17"
     cp1.last_modified = pendulum.datetime(year=2020, month=4, day=18)
     containers.append(cp1)
 
     cp3 = ContainerProperties()
-    cp3.name = 'mag-2020-05-01'
+    cp3.name = "mag-2020-05-01"
     cp3.last_modified = pendulum.datetime(year=2020, month=5, day=1)
     containers.append(cp3)
 
     cp2 = ContainerProperties()
-    cp2.name = 'mag-2020-04-24'
+    cp2.name = "mag-2020-04-24"
     cp2.last_modified = pendulum.datetime(year=2020, month=4, day=25)
     containers.append(cp2)
 
@@ -223,21 +257,20 @@ def make_containers():
 
 
 class TestMagArchiverClient(unittest.TestCase):
-
     def __init__(self, *args, **kwargs):
         super(TestMagArchiverClient, self).__init__(*args, **kwargs)
-        self.account_name = os.getenv('TEST_AZURE_STORAGE_ACCOUNT_NAME')
-        self.account_key = os.getenv('TEST_AZURE_STORAGE_ACCOUNT_KEY')
+        self.account_name = os.getenv("TEST_AZURE_STORAGE_ACCOUNT_NAME")
+        self.account_key = os.getenv("TEST_AZURE_STORAGE_ACCOUNT_KEY")
         create_table(self.account_name, self.account_key, MagRelease.TABLE_NAME)
 
     def test_secrets_hidden(self):
         # Check that account key is hidden
-        account_name = 'myaccountname'
-        secret = 'secret'
+        account_name = "myaccountname"
+        secret = "secret"
 
         # Check that account_key and sas_token are hidden
         client = MagArchiverClient(account_name=account_name, account_key=secret, sas_token=secret)
-        expected = f'MagArchiverClient(account_name={account_name}, account_key=hidden, sas_token=hidden)'
+        expected = f"MagArchiverClient(account_name={account_name}, account_key=hidden, sas_token=hidden)"
         self.assertEqual(client.__str__(), expected)
         self.assertEqual(client.__repr__(), expected)
         self.assertNotIn(secret, client.__str__())
@@ -245,12 +278,12 @@ class TestMagArchiverClient(unittest.TestCase):
 
         # Check that account_key and sas_token are None
         client = MagArchiverClient(account_name=account_name)
-        expected = f'MagArchiverClient(account_name={account_name}, account_key=None, sas_token=None)'
+        expected = f"MagArchiverClient(account_name={account_name}, account_key=None, sas_token=None)"
         self.assertEqual(client.__str__(), expected)
         self.assertEqual(client.__repr__(), expected)
 
-    @patch('mag_archiver.mag.list_containers')
-    @patch('pendulum.datetime.now')
+    @patch("mag_archiver.mag.list_containers")
+    @patch("pendulum.now")
     def test_list_containers(self, mock_now, mock_list_containers):
         # Mock time
         mock_now.return_value = pendulum.datetime(year=2020, month=5, day=1, minute=10)
@@ -280,8 +313,8 @@ class TestMagArchiverClient(unittest.TestCase):
         self.assertEqual(containers_in[2].name, containers_out[1].name)
         self.assertEqual(containers_in[0].name, containers_out[2].name)
 
-    @patch('mag_archiver.mag.list_containers')
-    @patch('pendulum.datetime.now')
+    @patch("mag_archiver.mag.list_containers")
+    @patch("pendulum.now")
     def test_update_releases(self, mock_now, mock_list_containers):
         # Mock time
         mock_now.return_value = pendulum.datetime(year=2020, month=5, day=1, minute=10)
@@ -303,10 +336,10 @@ class TestMagArchiverClient(unittest.TestCase):
             # Clean up
             service = TableService(account_name=self.account_name, account_key=self.account_key)
             for container in containers:
-                service.delete_entity(MagRelease.TABLE_NAME, 'mag', container.name.replace("mag-", ""))
+                service.delete_entity(MagRelease.TABLE_NAME, "mag", container.name.replace("mag-", ""))
 
-    @patch('mag_archiver.mag.list_containers')
-    @patch('pendulum.datetime.now')
+    @patch("mag_archiver.mag.list_containers")
+    @patch("pendulum.datetime.now")
     def test_list_releases(self, mock_now, mock_list_containers):
         # Mock time
         mock_now.return_value = pendulum.datetime(year=2020, month=5, day=1, hour=1)
@@ -328,39 +361,50 @@ class TestMagArchiverClient(unittest.TestCase):
             # Two releases
             start_date = pendulum.datetime(year=2020, month=4, day=17)
             end_date = pendulum.datetime(year=2020, month=5, day=1)
-            releases = client.list_releases(start_date=start_date, end_date=end_date, state=MagState.discovered,
-                                            date_type=MagDateType.release)
+            releases = client.list_releases(
+                start_date=start_date, end_date=end_date, state=MagState.discovered, date_type=MagDateType.release
+            )
             self.assertEqual(len(releases), 2)
 
             # 1 release
             start_date = pendulum.datetime(year=2020, month=4, day=17, minute=1)
             end_date = pendulum.datetime(year=2020, month=5, day=1)
-            releases = client.list_releases(start_date=start_date, end_date=end_date, state=MagState.discovered,
-                                            date_type=MagDateType.release)
+            releases = client.list_releases(
+                start_date=start_date, end_date=end_date, state=MagState.discovered, date_type=MagDateType.release
+            )
             self.assertEqual(len(releases), 1)
 
             # Three releases
             start_date = pendulum.datetime(year=2020, month=4, day=17)
             end_date = pendulum.datetime(year=2020, month=5, day=1, minute=1)
-            releases = client.list_releases(start_date=start_date, end_date=end_date, state=MagState.discovered,
-                                            date_type=MagDateType.release, reverse=False)
+            releases = client.list_releases(
+                start_date=start_date,
+                end_date=end_date,
+                state=MagState.discovered,
+                date_type=MagDateType.release,
+                reverse=False,
+            )
             self.assertEqual(len(releases), 3)
 
             # Sorting reverse=False
-            self.assertEqual(releases[0].row_key, '2020-04-17')
-            self.assertEqual(releases[1].row_key, '2020-04-24')
-            self.assertEqual(releases[2].row_key, '2020-05-01')
+            self.assertEqual(releases[0].row_key, "2020-04-17")
+            self.assertEqual(releases[1].row_key, "2020-04-24")
+            self.assertEqual(releases[2].row_key, "2020-05-01")
 
             # Sorting reverse=True
-            releases = client.list_releases(start_date=start_date, end_date=end_date,
-                                            state=MagState.discovered, date_type=MagDateType.release,
-                                            reverse=True)
-            self.assertEqual(releases[0].row_key, '2020-05-01')
-            self.assertEqual(releases[1].row_key, '2020-04-24')
-            self.assertEqual(releases[2].row_key, '2020-04-17')
+            releases = client.list_releases(
+                start_date=start_date,
+                end_date=end_date,
+                state=MagState.discovered,
+                date_type=MagDateType.release,
+                reverse=True,
+            )
+            self.assertEqual(releases[0].row_key, "2020-05-01")
+            self.assertEqual(releases[1].row_key, "2020-04-24")
+            self.assertEqual(releases[2].row_key, "2020-04-17")
 
         finally:
             # Clean up
             service = TableService(account_name=self.account_name, account_key=self.account_key)
             for container in containers:
-                service.delete_entity(MagRelease.TABLE_NAME, 'mag', container.name.replace("mag-", ""))
+                service.delete_entity(MagRelease.TABLE_NAME, "mag", container.name.replace("mag-", ""))

--- a/tests/test_mag.py
+++ b/tests/test_mag.py
@@ -224,7 +224,7 @@ class TestMagRelease(unittest.TestCase):
             # Update release
             release.state = MagState.archived
             release.archived_date = pendulum.now("UTC")
-            release.archived_date.set(microsecond=0)
+            release.archived_date = release.archived_date.set(microsecond=0)
             release.update()
 
             # Verify that release is updated

--- a/tests/test_mag.py
+++ b/tests/test_mag.py
@@ -224,6 +224,7 @@ class TestMagRelease(unittest.TestCase):
             # Update release
             release.state = MagState.archived
             release.archived_date = pendulum.now("UTC")
+            release.archived_date.set(microsecond=0)
             release.update()
 
             # Verify that release is updated

--- a/tests/test_mag.py
+++ b/tests/test_mag.py
@@ -223,7 +223,7 @@ class TestMagRelease(unittest.TestCase):
 
             # Update release
             release.state = MagState.archived
-            release.archived_date = pendulum.now("UTC").microsecond
+            release.archived_date = pendulum.now("UTC")
             release.update()
 
             # Verify that release is updated

--- a/tests/test_mag.py
+++ b/tests/test_mag.py
@@ -189,7 +189,7 @@ class TestMagRelease(unittest.TestCase):
 
             # Update release
             release.state = MagState.archived
-            release.archived_date = pendulum.utcnow().microsecond_(0)
+            release.archived_date = pendulum.now('UTC').microsecond
             release.update()
 
             # Verify that release is updated


### PR DESCRIPTION
Update pendulum to 2.1 branch.
Needed for Airflow 2 migration.

Given it's a dependency of the current observatory platform that's using airflow 1.10.x, the current observatory platform would need to stay tagged at the 2020.12.1.dev1 version.

When you merge, can you also publish a new version on pypi so I can test airflow 2 migration using this dependency.

codecov failing because text editing applied formatting, so it thinks I modified more code than it did.

Thanks!