### PR TITLE
upgrade azure-storage-blob requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 azure-cosmosdb-table==1.0.*
 azure-functions==1.2.*
-azure-storage-blob==12.3.*
 pendulum==2.1.*
+azure-storage-blob==12.8.*


### PR DESCRIPTION
airflow2 requires azure-storage-blob >= 12.7.0